### PR TITLE
Feature/add day support

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -84,6 +84,24 @@ export class FlipdownTimerCardEditor extends LitElement implements LovelaceCardE
     return this._config?.show_error || false;
   }
 
+  get _show_header(): boolean {
+    return this._config?.show_header || false;
+  }
+
+  get _show_day(): string {
+    if (this._config?.show_day === undefined) return 'false';
+    if (this._config?.show_day === true) return 'true';
+    if (this._config?.show_day === false) return 'false';
+    return String(this._config?.show_day);
+  }
+
+  get _show_hour(): string {
+    if (this._config?.show_hour === undefined) return 'false';
+    if (this._config?.show_hour === true) return 'true';
+    if (this._config?.show_hour === false) return 'false';
+    return String(this._config?.show_hour);
+  }
+
   get _tap_action(): ActionConfig {
     return this._config?.tap_action || { action: 'more-info' };
   }
@@ -160,6 +178,35 @@ export class FlipdownTimerCardEditor extends LitElement implements LovelaceCardE
                     @change=${this._valueChanged}
                   ></ha-switch>
                 </ha-formfield>
+                <ha-formfield .label=${`Toggle header ${this._show_header ? 'off' : 'on'}`}>
+                  <ha-switch
+                    .checked=${this._show_header !== false}
+                    .configValue=${'show_header'}
+                    @change=${this._valueChanged}
+                  ></ha-switch>
+                </ha-formfield>
+                <paper-dropdown-menu
+                  label="Show Day"
+                  @value-changed=${this._valueChanged}
+                  .configValue=${'show_day'}
+                >
+                  <paper-listbox slot="dropdown-content" .selected=${['false', 'true', 'auto'].indexOf(this._show_day)}>
+                    <paper-item>false</paper-item>
+                    <paper-item>true</paper-item>
+                    <paper-item>auto</paper-item>
+                  </paper-listbox>
+                </paper-dropdown-menu>
+                <paper-dropdown-menu
+                  label="Show Hour"
+                  @value-changed=${this._valueChanged}
+                  .configValue=${'show_hour'}
+                >
+                  <paper-listbox slot="dropdown-content" .selected=${['false', 'true', 'auto'].indexOf(this._show_hour)}>
+                    <paper-item>false</paper-item>
+                    <paper-item>true</paper-item>
+                    <paper-item>auto</paper-item>
+                  </paper-listbox>
+                </paper-dropdown-menu>
                 <ha-formfield .label=${`Toggle error ${this._show_error ? 'off' : 'on'}`}>
                   <ha-switch
                     .checked=${this._show_error !== false}
@@ -216,9 +263,21 @@ export class FlipdownTimerCardEditor extends LitElement implements LovelaceCardE
         delete tmpConfig[target.configValue];
         this._config = tmpConfig;
       } else {
+        let value = target.checked !== undefined ? target.checked : target.value;
+
+        // Convert string values to appropriate types for show_day and show_hour
+        if (target.configValue === 'show_day' || target.configValue === 'show_hour') {
+          if (value === 'true') {
+            value = true;
+          } else if (value === 'false') {
+            value = false;
+          }
+          // Leave 'auto' as a string
+        }
+
         this._config = {
           ...this._config,
-          [target.configValue]: target.checked !== undefined ? target.checked : target.value,
+          [target.configValue]: value,
         };
       }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,4 +15,33 @@ export interface FlipdownTimerCardConfig extends LovelaceCardConfig {
   show_error?: boolean;
   test_gui?: boolean;
   entity: string;
+  show_title?: boolean;
+  show_header?: boolean;
+  show_hour?: boolean | string;
+  show_day?: boolean | string;
+  duration?: string;
+  theme?: string;
+  localize?: {
+    button?: string;
+    header?: string;
+  };
+  localizeBtn?: string[];
+  localizeHeader?: string[];
+  styles?: {
+    rotor?: {
+      width?: string;
+      height?: string;
+      space?: string;
+      fontsize?: string;
+    };
+    button?: {
+      location?: string;
+      width?: string;
+      height?: string;
+      fontsize?: string;
+    };
+  };
+  tap_action?: any;
+  hold_action?: any;
+  double_tap_action?: any;
 }


### PR DESCRIPTION
 Add day support with auto mode for multi-day timers

  Summary

  Adds day display support to the Flipdown Timer Card with an auto mode that intelligently switches between day/hour/minute/second displays based on the
   remaining time.

  Features

  - show_day configuration option with three modes:
    - false (default): Days not shown, displays hours:minutes:seconds
    - true: Always shows days:hours (minutes and seconds hidden)
    - auto: Smart display that shows days:hours when ≥1 day, hours:minutes when <1 day but ≥1 hour, or minutes:seconds otherwise
  - Cascading auto behavior: Works hierarchically with existing show_hour auto mode for seamless time scale transitions
  - UI editor controls: Dropdown menus for both show_day and show_hour in the card editor
  - Home Assistant compatibility: Automatically converts day-based durations to HH:MM:SS format for timer services

  Configuration Example
```yaml
  type: custom:flipdown-timer-card
  entity: timer.your_timer
  show_day: auto
  show_hour: auto
  show_header: true
  ```